### PR TITLE
Prevent user from adding duplicate products

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -269,8 +269,24 @@ app.get('/sales/:salesPersonId', async (req) => {
 
 // Add new product
 app.post('/products', async (req, res) => {
+  // Check if request body is empty
   if (!req.body || req.body === '') {
     return res.send(app.httpErrors.badRequest('Information is required'));
+  }
+
+  // Check if product already exists
+  const count = await commitToDb(
+    prisma.product.count({
+      where: {
+        name: req.body.name,
+        manufacturer: req.body.manufacturer,
+        style: req.body.style,
+      },
+    })
+  );
+
+  if (count && count > 0) {
+    return res.send(app.httpErrors.badRequest('Product already exists'));
   }
 
   const result = await commitToDb(


### PR DESCRIPTION
User is now unable to add duplicate products. Product is a duplicate if the name, manufacturer, and style all exist in the database.